### PR TITLE
Filters and default to raw image

### DIFF
--- a/AdaptiveImageHandler.cs
+++ b/AdaptiveImageHandler.cs
@@ -61,15 +61,21 @@ namespace AdaptiveImages
 			int resolution = 0;
 
 			//check source file exists
-			if (!File.Exists(source_file))
+			if (!File.Exists(source_file)) { 
 				SendErrorImage(context, "Image not found");
+				return;
+			}
+
 			//look for cookie identifying resolution
 			if (context.Request.Cookies[cookie_name] != null) {
 				int client_width = 0;
 				if (int.TryParse(context.Request.Cookies[cookie_name].Value, out client_width)) {
 					resolution = resolutions.OrderBy(i => i).FirstOrDefault(break_point => client_width <= break_point);
-					if(default_raw && client_width > resolution)
+					//if resolution exceeds largest break-point, return raw image.
+					if(default_raw && client_width > resolution) { 
 						SendImage(context, source_file, browser_cache);
+						return;
+					}
 				} else {
 					//delete the mangled cookie
 					context.Response.Cookies[cookie_name].Value = string.Empty;
@@ -90,9 +96,11 @@ namespace AdaptiveImages
 					}
 					//send cached image
 					SendImage(context, cache_file, browser_cache);
+					return;
 				} else {
 					string file = GenerateImage(source_file, cache_file, resolution);
 					SendImage(context, file, browser_cache);
+					return;
 				}
 			} catch (Exception ex) { // send exception message as image
 				SendErrorImage(context, ex.Message);

--- a/Sample.Web.config
+++ b/Sample.Web.config
@@ -15,6 +15,8 @@
 		<add key="AdaptiveImages.MobileFirst" value="true"/>
 		<!--the name of the cookie containing the resolution value-->
 		<add key="AdaptiveImages.CookieName" value="resolution"/>
+		<!-- If the resolution is larger than the largest break-point, should we sent the raw image?-->
+		<add key="AdaptiveImages.DefaultRaw" value="false"/>
 	</appSettings>
 	<system.webServer>
 		<handlers>

--- a/Sample.Web.config
+++ b/Sample.Web.config
@@ -17,6 +17,11 @@
 		<add key="AdaptiveImages.CookieName" value="resolution"/>
 		<!-- If the resolution is larger than the largest break-point, should we sent the raw image?-->
 		<add key="AdaptiveImages.DefaultRaw" value="false"/>
+		<!-- a regex filter to determine what images to adapt and which to ignore. Note that backslashes 
+		do NOT to be escaped in the .config file -->
+		<add key="AdaptiveImages.RegexFilter" value=".*"/>
+		<!-- Should we use the regex filter? If false, processes all images. -->
+		<add key="AdaptiveImages.UseFilter" value="false"/>
 	</appSettings>
 	<system.webServer>
 		<handlers>


### PR DESCRIPTION
Added the ability to filter what does and doesn't get processed with a regex expression. This should serve as a solution to issue #2.

Added an option to load the raw image if the client's resolution exceeds the largest break-point set.

Also threw in `return` statements after any `SendImage()` or `SendErrorImage()` calls so the `ProcessRequest()` does not continue afterwards.
